### PR TITLE
double timeout to allow for Linux operations

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,3 +1,3 @@
 setTimeout(function() {
   chrome.runtime.sendMessage({}, function() {});
-}, 3000);
+}, 6000);


### PR DESCRIPTION
Zoom Closer often does not work on Linux because the tab gets closed before the call to the Zoom Linux desktop client can take place. Increasing the timeout limit should address this.